### PR TITLE
define __packed for Mac OS X

### DIFF
--- a/adjustmtu.c
+++ b/adjustmtu.c
@@ -59,6 +59,9 @@
 
 #undef RTMSG_DEBUG
 
+#ifndef __packed
+#define __packed __attribute__((packed))
+#endif
 
 int main(int, char *[]);
 static int usage(void);


### PR DESCRIPTION
In some platform, __packed is not present and fails to compile adjustmtu.
This patch defines __packed for such environment.

I've tested this on Mac OS X 10.11.6 with clang-800.0.42.1.