### PR TITLE
don't set SO_DONTROUTE when dontroute is 0

### DIFF
--- a/adjustmtu.c
+++ b/adjustmtu.c
@@ -317,7 +317,7 @@ detectmtu(struct in_addr dst, struct in_addr src, int dontroute)
 		logging(LOG_ERR, "setsockopt: IP_HDRINCL", strerror(errno));
 		return -1;
 	}
-	if (setsockopt(s, SOL_SOCKET, SO_DONTROUTE, (char *)&n, sizeof(n)) == -1) {
+	if (dontroute && setsockopt(s, SOL_SOCKET, SO_DONTROUTE, (char *)&n, sizeof(n)) == -1) {
 		logging(LOG_ERR, "setsockopt: SO_DONTROUTE", strerror(errno));
 		return -1;
 	}


### PR DESCRIPTION
Fix whether to set SO_DONTROUTE depending on dontroute value.
Currently adjustmtu always activate this option. 
But it seems One Shot mode allows ICMP packet to be routed, so this option should be disabled.

Signed-off-by: enukane <enukane@glenda9.org>